### PR TITLE
Updated Web3 to version 4.8.2 and fixed some test dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "lib/pymaker"]
 	path = lib/pymaker
-	url = https://github.com/EdNoepel/pymaker.git
-	branch = web3-update
+	url = https://github.com/makerdao/pymaker.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "lib/pymaker"]
 	path = lib/pymaker
-	url = https://github.com/makerdao/pymaker.git
+	url = https://github.com/EdNoepel/pymaker.git
+	branch = web3-update

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-cov == 2.5.1
 pytest-mock == 1.6.3
 pytest-timeout == 1.2.1
 asynctest == 0.11.1
+eth-tester[py-evm]==0.1.0b27

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytz == 2017.3
-web3 == 4.5.0
+web3 == 4.8.2
 requests == 2.18.4
 python-dateutil == 2.6.1
 websockets == 6.0.0


### PR DESCRIPTION
Unit tests require eth-tester[py-evm].  Please revert .gitmodules once pymaker pull is approved and merged.