### PR TITLE
Handle OKEX API update 

### DIFF
--- a/tests/manual_test_okex.py
+++ b/tests/manual_test_okex.py
@@ -28,8 +28,8 @@ print("OKEXApi created\n")
 
 
 pair = "mkr_usdt"
-# l1 = okex.ticker(pair)
-# print(f"best bid: {l1['best_bid']}  best ask: {l1['best_ask']}")
+#l1 = okex.ticker(pair)
+#print(f"best bid: {l1['best_bid']}  best ask: {l1['best_ask']}")
 # book = okex.depth(pair)
 # print(f"bids: {book['bids'][0:3]}")
 # print(f"asks: {book['asks'][0:3]}")
@@ -42,8 +42,8 @@ print(f"                     MKR: {balances['MKR']}")
 
 
 # price in terms of quote currency (USDT), size in terms of base currency (MKR)
-# print(okex.place_order(pair, False, Wad.from_number(699.33), Wad.from_number(0.25)))
-# print(okex.cancel_order(pair, "2502374107516928"))
+# print(okex.place_order(pair, False, Wad.from_number(513), Wad.from_number(0.1)))
+# print(okex.cancel_order(pair, "2740825307024384"))
 
 
 def print_orders(orders):
@@ -70,8 +70,8 @@ def print_trades(trades):
 orders = okex.get_orders(pair)
 print_orders(orders)
 # Gets all orders
-orders = okex.get_orders_history(pair, 9)
-print_orders(orders)
+#orders = okex.get_orders_history(pair, 9)
+#print_orders(orders)
 
 #trades = okex.get_trades(pair)
 #print(trades[:3])

--- a/tests/test_okex.py
+++ b/tests/test_okex.py
@@ -73,9 +73,11 @@ class OkexMockServer:
             return MockedResponse(text=OkexMockServer.responses["accounts1"])
         elif "/api/spot/v3/orders_pending" in url:
             return MockedResponse(text=OkexMockServer.responses["orders1"])
-        elif re.search(r"\/api\/spot\/v3\/orders\?status=[\w_%]+&instrument_id=[\w\-_]+&limit=\d+", url):
+        elif re.search(r"\/api\/spot\/v3\/orders\?state=[\w_%]+&instrument_id=[\w\-_]+&limit=\d+", url):
             return MockedResponse(text=OkexMockServer.responses["orders2"])
-        elif re.search(r"\/api\/spot\/v3\/orders\?status=[\w_%]+&instrument_id=[\w\-_]+", url):\
+        elif re.search(r"\/api\/spot\/v3\/orders\?state=1&instrument_id=[\w\-_]+", url):
+            return MockedResponse(text="[]")  # assume no partial fills
+        elif re.search(r"\/api\/spot\/v3\/orders\?state=2&instrument_id=[\w\-_]+", url):
             return MockedResponse(text=OkexMockServer.responses["trades1"])
         elif re.search(r"\/api\/spot\/v3\/instruments\/[\w\-_]+\/trades", url):
             return MockedResponse(text=OkexMockServer.responses["trades2"])
@@ -234,6 +236,7 @@ class TestOKEX:
         for index, trade in enumerate(trades):
             assert(isinstance(trade, Trade))
             if trade.trade_id in by_tradeid:
+                print(f"found duplicate trade {trade.trade_id}")
                 duplicate_count += 1
                 if duplicate_first_found < 0:
                     duplicate_first_found = index


### PR DESCRIPTION
OKEX removed order/trade queries by status, replacing with a new state parameter.  Treat empty error code as success (based on manual testing).