### PR TITLE
Fix issue with Travis grabbing the wrong version of eth-typing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ install:
   - pip install virtualenv --upgrade
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
-  - pip list
 
 script:
   - ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
   - pip install virtualenv --upgrade
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
+  - pip list
 
 script:
   - ./test.sh

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
 attrs == 19.1.0
 codecov == 2.0.9
-pytest == 3.3.0
+pytest == 3.4.1
 pytest-asyncio == 0.8.0
 pytest-cov == 2.5.1
 pytest-mock == 1.6.3
 pytest-timeout == 1.2.1
 asynctest == 0.11.1
-eth-tester[py-evm] == 0.1.0b27
+eth-tester[py-evm] == 0.1.0b29
 attrs == 19.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pytz == 2017.3
 web3 == 4.8.2
-eth-typing == 2.1.0
 requests == 2.18.4
 python-dateutil == 2.8.1
 websockets == 6.0.0


### PR DESCRIPTION
A few issues came together to cause this behavior:
- `eth-utils` was unhappy with our version of `pytest`
- a bug in `eth-tester` 0.1.0b27 was resolved in 0.1.0b29
- a new version of `eth-typing` was released and travis (for some reason) ignored the pegged version in `requirements.txt`

This change embraces the latest version of `eth-typing` rather than trying to peg it at a version that non-travis environments are happy with. 
