### PR TITLE
use pairhourid as opposed to timestamp for generating trade id

### DIFF
--- a/pyexchange/uniswapv2_analytics.py
+++ b/pyexchange/uniswapv2_analytics.py
@@ -320,22 +320,13 @@ class UniswapV2Analytics(Contract):
         mints_in_last_two_days = list(filter(lambda mint: int(mint['timestamp']) > two_days_ago_unix, mint_events))
 
         if current_liquidity != Wad.from_number(0) and len(mints_in_last_two_days) >= 1:
-            if self.our_last_pair_hour_timestamp > mints_in_last_two_days[-1]['timestamp']:
-                start_timestamp = self.our_last_pair_hour_timestamp
-            else:
-                start_timestamp = mints_in_last_two_days[-1]['timestamp']
+            start_timestamp = max(self.our_last_pair_hour_timestamp, mints_in_last_two_days[-1]['timestamp'])
             end_timestamp = current_time
         elif current_liquidity != Wad.from_number(0) and len(mints_in_last_two_days) == 0:
-            if self.our_last_pair_hour_timestamp > two_days_ago_unix:
-                start_timestamp = self.our_last_pair_hour_timestamp
-            else:
-                start_timestamp = two_days_ago_unix
+            start_timestamp = max(our_last_pair_hour_timestamp, two_days_ago_unix)
             end_timestamp = current_time
         elif current_liquidity == Wad.from_number(0) and len(mints_in_last_two_days) >= 1:
-            if self.our_last_pair_hour_timestamp > mints_in_last_two_days[-1]['timestamp']:
-                start_timestamp = self.our_last_pair_hour_timestamp
-            else:
-                start_timestamp = mints_in_last_two_days[-1]['timestamp']
+            start_timestamp = max(self.our_last_pair_hour_timestamp, mints_in_last_two_days[-1]['timestamp'])
             end_timestamp = last_burn_timestamp if last_burn_timestamp != None else current_time
         else:
             return trades_list

--- a/pyexchange/uniswapv2_analytics.py
+++ b/pyexchange/uniswapv2_analytics.py
@@ -59,18 +59,12 @@ class UniswapTrade(Trade):
         if trade['pair']['token0']['id'] == base_token.address.address:
             swap_price = Wad.from_number(trade['reserve1']) / Wad.from_number(trade['reserve0'])
 
-            base_token_volume = Wad.from_number(trade['hourlyVolumeToken0']) * swap_price
-            quote_token_volume = Wad.from_number(trade['hourlyVolumeToken1']) / swap_price
-
             is_sell = Wad.from_number(trade['reserve1']) < previous_base_token_reserves
 
             amount = our_pool_share * Wad.from_number(trade['hourlyVolumeToken0'])
 
         else:
             swap_price = Wad.from_number(trade['reserve0']) / Wad.from_number(trade['reserve1'])
-
-            base_token_volume = Wad.from_number(trade['hourlyVolumeToken0']) / swap_price
-            quote_token_volume = Wad.from_number(trade['hourlyVolumeToken1']) * swap_price
 
             is_sell = Wad.from_number(trade['reserve0']) < previous_base_token_reserves
 
@@ -96,18 +90,12 @@ class UniswapTrade(Trade):
         if trade['pair']['token0']['id'] == base_token.address.address:
             swap_price = Wad.from_number(trade['reserve1']) / Wad.from_number(trade['reserve0'])
 
-            base_token_volume = Wad.from_number(trade['hourlyVolumeToken0']) * swap_price
-            quote_token_volume = Wad.from_number(trade['hourlyVolumeToken1']) / swap_price
-
             is_sell = Wad.from_number(trade['reserve1']) < previous_base_token_reserves
 
             amount = Wad.from_number(trade['hourlyVolumeToken0'])
 
         else:
             swap_price = Wad.from_number(trade['reserve0']) / Wad.from_number(trade['reserve1'])
-
-            base_token_volume = Wad.from_number(trade['hourlyVolumeToken0']) / swap_price
-            quote_token_volume = Wad.from_number(trade['hourlyVolumeToken1']) * swap_price
 
             is_sell = Wad.from_number(trade['reserve0']) < previous_base_token_reserves
 

--- a/pyexchange/uniswapv2_analytics.py
+++ b/pyexchange/uniswapv2_analytics.py
@@ -77,7 +77,8 @@ class UniswapTrade(Trade):
             amount = our_pool_share * Wad.from_number(trade['hourlyVolumeToken1'])
 
         timestamp = int(trade['hourStartUnix'])
-        trade_id = hashlib.sha256(str(timestamp).encode()).hexdigest()
+        unhashed_id = str(trade['id'])
+        trade_id = hashlib.sha256(unhashed_id.encode()).hexdigest()
         return Trade(trade_id=trade_id,
                      timestamp=timestamp,
                      pair=pair,
@@ -113,7 +114,8 @@ class UniswapTrade(Trade):
             amount = Wad.from_number(trade['hourlyVolumeToken1'])
 
         timestamp = int(trade['hourStartUnix'])
-        trade_id = hashlib.sha256(str(timestamp).encode()).hexdigest()
+        unhashed_id = str(trade['id'])
+        trade_id = hashlib.sha256(unhashed_id.encode()).hexdigest()
         return Trade(trade_id=trade_id,
                      timestamp=timestamp,
                      pair=pair,
@@ -353,6 +355,7 @@ class UniswapV2Analytics(Contract):
                     token0Price
                     token1Price
                 }
+                id
                 hourStartUnix
                 hourlyVolumeToken0
                 hourlyVolumeToken1
@@ -405,6 +408,7 @@ class UniswapV2Analytics(Contract):
                     token0Price
                     token1Price
                 }
+                id
                 hourStartUnix
                 hourlyVolumeToken0
                 hourlyVolumeToken1


### PR DESCRIPTION
There are rounding issues that appear in the response objects price and amount attributes from Graph Protocol. This is causing some of the trades to be unnecessarily updated. To avoid excessively updating large numbers of trades, this PR stores the last time it queried and uses that timestamp as the starting point for any future queries.