### PR TITLE
Lock order deletion from local order book

### DIFF
--- a/pyexchange/erisx.py
+++ b/pyexchange/erisx.py
@@ -278,6 +278,10 @@ class ErisxApi(PyexAPI):
             elif new_order.get(simplefix.TAG_ORDERREJREASON) == b'23':
                 self.logger.warning(f"Failed to place order as order would have exceeded balance limits")
             return ''
+        # handle unsolicited cancellations
+        elif new_order.get(b'5001') is not None:
+            self.logger.warning(f"Failed to place order due to {new_order.get(simplefix.TAG_TEXT)}")
+            return ''
 
         erisx_oid = new_order.get(simplefix.TAG_ORDERID).decode('utf-8')
         client_oid = new_order.get(simplefix.TAG_CLORDID).decode('utf-8')

--- a/pyexchange/fix.py
+++ b/pyexchange/fix.py
@@ -281,6 +281,9 @@ class FixEngine:
                         # Remove orders that have been cancelled from the order book
                         if message.get(simplefix.TAG_EXECTYPE) == simplefix.EXECTYPE_CANCELED:
                             del self.order_book[client_order_id]
+                        # Remove orders that recieve an UnsolicitedCancel response
+                        if message.get(b'5001') is not None:
+                            del self.order_book[client_order_id]                            
                         return message
             await asyncio.sleep(0.3)
 


### PR DESCRIPTION
Logs were showing key errors from attempting to delete entries that were no longer present. This should resolve that issue by ensuring that orders are removed from the orderbook on receipt of cancellation or fill.